### PR TITLE
Add Order model and migration enum

### DIFF
--- a/backend/app/Enums/OrderStatus.php
+++ b/backend/app/Enums/OrderStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enums;
+
+enum OrderStatus: string
+{
+    case New = 'new';
+    case Driving = 'driving';
+    case Canceled = 'canceled';
+    case Completed = 'completed';
+}

--- a/backend/app/Models/Order.php
+++ b/backend/app/Models/Order.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use App\Enums\OrderStatus;
+
+class Order extends Model
+{
+    /**
+     * The primary key type is UUID.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+
+    /**
+     * Indicates if the model should be timestamped.
+     * Only created_at column exists.
+     *
+     * @var bool
+     */
+    public $timestamps = false;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'id',
+        'created_at',
+        'passenger_phone',
+        'from_address',
+        'from_lat',
+        'from_lng',
+        'from_description',
+        'to_address',
+        'to_lat',
+        'to_lng',
+        'to_description',
+        'status',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'created_at' => 'datetime',
+        'status' => OrderStatus::class,
+    ];
+}

--- a/backend/database/migrations/2023_01_01_000000_create_orders_table.php
+++ b/backend/database/migrations/2023_01_01_000000_create_orders_table.php
@@ -13,14 +13,14 @@ return new class extends Migration
             $table->timestamp('created_at')->useCurrent();
             $table->string('passenger_phone');
             $table->string('from_address');
-            $table->decimal('from_latitude', 10, 7);
-            $table->decimal('from_longitude', 10, 7);
+            $table->decimal('from_lat', 10, 7);
+            $table->decimal('from_lng', 10, 7);
             $table->string('from_description')->nullable();
             $table->string('to_address');
-            $table->decimal('to_latitude', 10, 7);
-            $table->decimal('to_longitude', 10, 7);
+            $table->decimal('to_lat', 10, 7);
+            $table->decimal('to_lng', 10, 7);
             $table->string('to_description')->nullable();
-            $table->enum('status', ['new', 'in_progress', 'canceled', 'completed'])->default('new');
+            $table->enum('status', ['new', 'driving', 'canceled', 'completed'])->default('new');
         });
     }
 


### PR DESCRIPTION
## Summary
- update the `orders` migration to use required column names
- add `OrderStatus` enum
- create `Order` model with enum casting

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858e87104b88329a8795bf7180a2b76