### PR TITLE
Implement scheduled order status updates

### DIFF
--- a/backend/app/Console/Commands/UpdateOrderStatuses.php
+++ b/backend/app/Console/Commands/UpdateOrderStatuses.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\Order;
+use App\Enums\OrderStatus;
+use Illuminate\Support\Facades\Date;
+
+class UpdateOrderStatuses extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'orders:update-statuses';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Update order statuses from new to driving and from driving to completed';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $now = Date::now();
+
+        // Orders created more than a minute ago move from "new" to "driving".
+        Order::where('status', OrderStatus::New)
+            ->where('created_at', '<=', $now->clone()->subMinute())
+            ->update(['status' => OrderStatus::Driving]);
+
+        // Orders that have been in "driving" status for more than a minute
+        // (i.e. created more than two minutes ago) move to "completed".
+        Order::where('status', OrderStatus::Driving)
+            ->where('created_at', '<=', $now->clone()->subMinutes(2))
+            ->update(['status' => OrderStatus::Completed]);
+
+        return Command::SUCCESS;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use App\Console\Commands\UpdateOrderStatuses;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -9,6 +10,11 @@ class Kernel extends ConsoleKernel
 {
     protected function schedule(Schedule $schedule): void
     {
-        // $schedule->job(new UpdateOrderStatuses)->everyMinute();
+        $schedule->command('orders:update-statuses')->everyMinute();
+    }
+
+    protected function commands(): void
+    {
+        $this->load(__DIR__.'/Commands');
     }
 }


### PR DESCRIPTION
## Summary
- add `orders:update-statuses` artisan command
- schedule the command in `Kernel` to run every minute

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858f273a92c8329a994a76e560686b8