### PR TITLE
Add basic React pages for orders

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,10 @@
   "private": true,
   "dependencies": {
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "react-router-dom": "^6.4.0",
+    "react-window": "^1.8.6",
+    "react-virtualized-auto-sizer": "^1.0.7"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { OrdersPage } from './pages/OrdersPage';
+import { NewOrderPage } from './pages/NewOrderPage';
+import { OrderDetailPage } from './pages/OrderDetailPage';
+
+export const App: React.FC = () => (
+  <BrowserRouter>
+    <Routes>
+      <Route path="/" element={<Navigate to="/orders" replace />} />
+      <Route path="/orders" element={<OrdersPage />} />
+      <Route path="/orders/new" element={<NewOrderPage />} />
+      <Route path="/orders/:id" element={<OrderDetailPage />} />
+    </Routes>
+  </BrowserRouter>
+);

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,0 +1,43 @@
+export type Order = {
+  id: string;
+  phone: string;
+  from_address: string;
+  to_address: string;
+  description: string;
+  status: string;
+};
+
+const API_URL = '/api';
+
+export async function fetchOrders(status?: string, page = 1): Promise<Order[]> {
+  const params = new URLSearchParams();
+  if (status) params.append('status', status);
+  params.append('page', page.toString());
+  const res = await fetch(`${API_URL}/orders?${params}`);
+  return res.json();
+}
+
+export async function fetchOrder(id: string): Promise<Order> {
+  const res = await fetch(`${API_URL}/orders/${id}`);
+  return res.json();
+}
+
+export async function createOrder(data: Omit<Order, 'id' | 'status'>) {
+  const res = await fetch(`${API_URL}/orders`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  return res.json();
+}
+
+export async function cancelOrder(id: string) {
+  await fetch(`${API_URL}/orders/${id}`, { method: 'DELETE' });
+}
+
+export async function geocodeAddress(address: string): Promise<string[]> {
+  const url = `https://geocode-maps.yandex.ru/1.x/?format=json&geocode=${encodeURIComponent(address)}`;
+  const res = await fetch(url);
+  const json = await res.json();
+  return json.response.GeoObjectCollection.featureMember.map((f: any) => f.GeoObject.name);
+}

--- a/frontend/src/components/OrdersList.tsx
+++ b/frontend/src/components/OrdersList.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState, useRef, useCallback } from 'react';
+import { FixedSizeList as List } from 'react-window';
+import AutoSizer from 'react-virtualized-auto-sizer';
+import { Order, fetchOrders, cancelOrder } from '../api';
+
+interface OrdersListProps {
+  status?: string;
+}
+
+export const OrdersList: React.FC<OrdersListProps> = ({ status }) => {
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [page, setPage] = useState(1);
+  const listRef = useRef<List>(null);
+
+  useEffect(() => {
+    fetchOrders(status, page).then(data => setOrders(prev => [...prev, ...data]));
+  }, [status, page]);
+
+  const loadMore = useCallback(() => {
+    setPage(p => p + 1);
+  }, []);
+
+  const handleCancel = async (id: string) => {
+    await cancelOrder(id);
+    setOrders(list => list.filter(o => o.id !== id));
+  };
+
+  const Row = ({ index, style }: { index: number; style: React.CSSProperties }) => {
+    const order = orders[index];
+    if (!order) return null;
+    return (
+      <div style={style} className="order-row">
+        <div>{order.from_address} → {order.to_address}</div>
+        <div>{order.status}</div>
+        {order.status === 'active' && (
+          <button onClick={() => handleCancel(order.id)}>Cancel</button>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <AutoSizer>
+      {({ width, height }) => (
+        <List
+          height={height}
+          itemCount={orders.length}
+          itemSize={60}
+          width={width}
+          ref={listRef}
+          onItemsRendered={({ visibleStopIndex }) => {
+            if (visibleStopIndex >= orders.length - 1) loadMore();
+          }}
+        >
+          {Row}
+        </List>
+      )}
+    </AutoSizer>
+  );
+};

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-
-const App = () => <div>Taxi Orders App</div>;
+import { App } from './App';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(<App />);

--- a/frontend/src/pages/NewOrderPage.tsx
+++ b/frontend/src/pages/NewOrderPage.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import { createOrder, geocodeAddress } from '../api';
+
+export const NewOrderPage: React.FC = () => {
+  const [phone, setPhone] = useState('');
+  const [from, setFrom] = useState('');
+  const [to, setTo] = useState('');
+  const [description, setDescription] = useState('');
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+
+  const handleGeocode = async (value: string) => {
+    setSuggestions(await geocodeAddress(value));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await createOrder({ phone, from_address: from, to_address: to, description });
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h1>New Order</h1>
+      <input value={phone} onChange={e => setPhone(e.target.value)} placeholder="Phone" />
+      <input
+        value={from}
+        onChange={e => {
+          setFrom(e.target.value);
+          handleGeocode(e.target.value);
+        }}
+        placeholder="From address"
+      />
+      <input
+        value={to}
+        onChange={e => {
+          setTo(e.target.value);
+          handleGeocode(e.target.value);
+        }}
+        placeholder="To address"
+      />
+      <textarea value={description} onChange={e => setDescription(e.target.value)} placeholder="Description" />
+      <button type="submit">Create</button>
+      {suggestions.length > 0 && (
+        <ul>
+          {suggestions.map(s => (
+            <li key={s}>{s}</li>
+          ))}
+        </ul>
+      )}
+    </form>
+  );
+};

--- a/frontend/src/pages/OrderDetailPage.tsx
+++ b/frontend/src/pages/OrderDetailPage.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { fetchOrder, cancelOrder, Order } from '../api';
+
+export const OrderDetailPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const [order, setOrder] = useState<Order | null>(null);
+
+  useEffect(() => {
+    if (id) fetchOrder(id).then(setOrder);
+  }, [id]);
+
+  const handleCancel = async () => {
+    if (!id) return;
+    await cancelOrder(id);
+    setOrder(o => o && { ...o, status: 'canceled' });
+  };
+
+  if (!order) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h1>Order</h1>
+      <p>From: {order.from_address}</p>
+      <p>To: {order.to_address}</p>
+      <p>Status: {order.status}</p>
+      {order.status === 'active' && <button onClick={handleCancel}>Cancel</button>}
+    </div>
+  );
+};

--- a/frontend/src/pages/OrdersPage.tsx
+++ b/frontend/src/pages/OrdersPage.tsx
@@ -1,0 +1,22 @@
+import React, { useState } from 'react';
+import { OrdersList } from '../components/OrdersList';
+
+export const OrdersPage: React.FC = () => {
+  const [status, setStatus] = useState<string>('');
+
+  return (
+    <div>
+      <h1>Orders</h1>
+      <label>Status filter: </label>
+      <select value={status} onChange={e => setStatus(e.target.value)}>
+        <option value="">All</option>
+        <option value="active">Active</option>
+        <option value="completed">Completed</option>
+        <option value="canceled">Canceled</option>
+      </select>
+      <div style={{ height: '80vh' }}>
+        <OrdersList status={status || undefined} />
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- scaffold pages for Orders, Order details, and New Order form
- implement a virtualized orders list
- add API helper with Yandex geocoder call
- wire up routing via `App` component
- update dependencies

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6858fa6e4d908329982d13950225097e