### PR TITLE
Integrate Yandex geocoder on order form

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,9 +1,14 @@
 export type Order = {
   id: string;
-  phone: string;
+  passenger_phone: string;
   from_address: string;
+  from_lat: number;
+  from_lng: number;
+  from_description?: string;
   to_address: string;
-  description: string;
+  to_lat: number;
+  to_lng: number;
+  to_description?: string;
   status: string;
 };
 
@@ -40,4 +45,17 @@ export async function geocodeAddress(address: string): Promise<string[]> {
   const res = await fetch(url);
   const json = await res.json();
   return json.response.GeoObjectCollection.featureMember.map((f: any) => f.GeoObject.name);
+}
+
+export async function geocodeCoordinates(
+  address: string
+): Promise<{ lat: number; lng: number } | null> {
+  const url = `https://geocode-maps.yandex.ru/1.x/?format=json&geocode=${encodeURIComponent(address)}`;
+  const res = await fetch(url);
+  const json = await res.json();
+  const first = json.response.GeoObjectCollection.featureMember[0];
+  if (!first) return null;
+  const pos: string = first.GeoObject.Point.pos; // "lng lat"
+  const [lng, lat] = pos.split(' ').map(parseFloat);
+  return { lat, lng };
 }

--- a/frontend/src/pages/NewOrderPage.tsx
+++ b/frontend/src/pages/NewOrderPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { createOrder, geocodeAddress } from '../api';
+import { createOrder, geocodeAddress, geocodeCoordinates } from '../api';
 
 export const NewOrderPage: React.FC = () => {
   const [phone, setPhone] = useState('');
@@ -7,14 +7,37 @@ export const NewOrderPage: React.FC = () => {
   const [to, setTo] = useState('');
   const [description, setDescription] = useState('');
   const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [fromLat, setFromLat] = useState('');
+  const [fromLng, setFromLng] = useState('');
+  const [toLat, setToLat] = useState('');
+  const [toLng, setToLng] = useState('');
 
-  const handleGeocode = async (value: string) => {
+  const handleGeocode = async (value: string, type: 'from' | 'to') => {
     setSuggestions(await geocodeAddress(value));
+    const coords = await geocodeCoordinates(value);
+    if (!coords) return;
+    if (type === 'from') {
+      setFromLat(coords.lat.toString());
+      setFromLng(coords.lng.toString());
+    } else {
+      setToLat(coords.lat.toString());
+      setToLng(coords.lng.toString());
+    }
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await createOrder({ phone, from_address: from, to_address: to, description });
+    await createOrder({
+      passenger_phone: phone,
+      from_address: from,
+      from_lat: parseFloat(fromLat),
+      from_lng: parseFloat(fromLng),
+      from_description: description,
+      to_address: to,
+      to_lat: parseFloat(toLat),
+      to_lng: parseFloat(toLng),
+      to_description: description,
+    });
   };
 
   return (
@@ -25,18 +48,22 @@ export const NewOrderPage: React.FC = () => {
         value={from}
         onChange={e => {
           setFrom(e.target.value);
-          handleGeocode(e.target.value);
+          handleGeocode(e.target.value, 'from');
         }}
         placeholder="From address"
       />
+      <input value={fromLat} readOnly placeholder="From lat" />
+      <input value={fromLng} readOnly placeholder="From lng" />
       <input
         value={to}
         onChange={e => {
           setTo(e.target.value);
-          handleGeocode(e.target.value);
+          handleGeocode(e.target.value, 'to');
         }}
         placeholder="To address"
       />
+      <input value={toLat} readOnly placeholder="To lat" />
+      <input value={toLng} readOnly placeholder="To lng" />
       <textarea value={description} onChange={e => setDescription(e.target.value)} placeholder="Description" />
       <button type="submit">Create</button>
       {suggestions.length > 0 && (


### PR DESCRIPTION
## Summary
- extend `Order` type with coordinate fields
- add `geocodeCoordinates` helper for calling Yandex API
- automatically fill coordinates in `/orders/new` form

## Testing
- `npx tsc --noEmit` *(fails: cannot access npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_6858fb86b7848329b6ca70cf5f2212b8