### PR TITLE
Fix docker-compose env and volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,10 +14,8 @@ services:
 
   backend:
     build: ./backend
-    volumes:
-      - ./backend:/var/www/html
     env_file:
-      - ./backend/.env.example
+      - ./backend/.env
     depends_on:
       - db
     ports:
@@ -25,8 +23,6 @@ services:
 
   frontend:
     build: ./frontend
-    volumes:
-      - ./frontend:/app
     environment:
       - REACT_APP_API_URL=http://backend:8000/api
     depends_on:


### PR DESCRIPTION
## Summary
- ensure backend uses .env instead of .env.example
- drop bind mounts that removed built dependencies

## Testing
- `docker-compose config` *(fails: docker-compose not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858fd26966083299ff2d7ffcbd74457