### PR TITLE
Add example PHPUnit tests for OrderController

### DIFF
--- a/backend/tests/Feature/OrderControllerTest.php
+++ b/backend/tests/Feature/OrderControllerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use App\Models\Order;
+use App\Enums\OrderStatus;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Date;
+
+class OrderControllerTest extends TestCase
+{
+    public function test_order_can_be_created()
+    {
+        // Example payload for creating an order
+        $payload = [
+            'passenger_phone' => '555-1111',
+            'from_address' => 'A street',
+            'from_lat' => 10.0,
+            'from_lng' => 20.0,
+            'to_address' => 'B street',
+            'to_lat' => 30.0,
+            'to_lng' => 40.0,
+        ];
+
+        // Make request to the store endpoint
+        $response = $this->postJson('/api/order', $payload);
+
+        $response->assertCreated();
+        $this->assertSame(OrderStatus::New->value, $response['status']);
+        $this->assertDatabaseHas('orders', [
+            'passenger_phone' => '555-1111',
+            'status' => OrderStatus::New->value,
+        ]);
+    }
+
+    public function test_order_can_be_canceled()
+    {
+        $order = Order::create([
+            'id' => (string) Str::uuid(),
+            'created_at' => Date::now(),
+            'passenger_phone' => '555-2222',
+            'from_address' => 'A',
+            'from_lat' => 1,
+            'from_lng' => 2,
+            'to_address' => 'B',
+            'to_lat' => 3,
+            'to_lng' => 4,
+            'status' => OrderStatus::New,
+        ]);
+
+        $response = $this->deleteJson('/api/order/'.$order->id);
+
+        $response->assertNoContent();
+        $this->assertDatabaseHas('orders', [
+            'id' => $order->id,
+            'status' => OrderStatus::Canceled->value,
+        ]);
+    }
+}

--- a/backend/tests/TestCase.php
+++ b/backend/tests/TestCase.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    // Minimal base test case for example purposes
+}


### PR DESCRIPTION
## Summary
- add minimal TestCase class and OrderController example tests

## Testing
- `./vendor/bin/phpunit --filter=OrderControllerTest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6858ff788ddc832980939483deb2291e