### PR TITLE
Use Vite for frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The frontend communicates with the backend via `http://backend:8000/api` inside 
   - `Dockerfile` – builds the PHP-FPM container
   - `composer.json` – project dependencies
   - `database/migrations/` – includes an example migration for the `orders` table
-- `frontend/` – React application
+ - `frontend/` – React application powered by **Vite**
   - `Dockerfile` – dev server image
   - `package.json` – npm dependencies and scripts
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
   frontend:
     build: ./frontend
     environment:
-      - REACT_APP_API_URL=http://backend:8000/api
+      - VITE_API_URL=http://backend:8000/api
     depends_on:
       - backend
     ports:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,10 +2,10 @@ FROM node:18
 
 WORKDIR /app
 
-COPY package.json tsconfig.json ./
+COPY package.json tsconfig.json vite.config.ts index.html ./
 RUN npm install
-COPY . ./
+COPY src ./src
 
-CMD ["npm", "start"]
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
 
 EXPOSE 3000

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Taxi Orders</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,9 +10,15 @@
     "react-virtualized-auto-sizer": "^1.0.7"
   },
   "devDependencies": {
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "vite": "^4.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0"
   },
   "scripts": {
-    "start": "react-scripts start"
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
   }
 }

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -12,7 +12,7 @@ export type Order = {
   status: string;
 };
 
-const API_URL = '/api';
+const API_URL = import.meta.env.VITE_API_URL || '/api';
 
 export async function fetchOrders(status?: string, page = 1): Promise<Order[]> {
   const params = new URLSearchParams();

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  server: {
+    host: true,
+    port: 3000,
+    proxy: {
+      '/api': {
+        target: 'http://backend:8000',
+        changeOrigin: true,
+      },
+    },
+  },
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- migrate React frontend to Vite
- add Vite config and entry HTML
- update Dockerfile and compose config for Vite
- document that Vite is used in the README

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685925c79b308329a2e6cfbda74c4835